### PR TITLE
Fix tests for Python 3.14

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,7 +9,7 @@ class TestService:
     @pytest.mark.parametrize(
         ('rate_limit', 'period'), ((1, 0.5), (3, 1.0), (100, 1.5))
     )
-    def test_service(self, rate_limit: int, period: float):
+    def test_service(self, rate_limit: int, period: float, event_loop):
         s = Service(rate_limit, period)
 
         async def request(value: float):
@@ -22,7 +22,7 @@ class TestService:
     @pytest.mark.parametrize(
         ('max_simultaneous',), ((1,), (3,), (100,))
     )
-    def test_service_simultaneous(self, max_simultaneous: int):
+    def test_service_simultaneous(self, max_simultaneous: int, event_loop):
         s = ServiceSimultaneous(max_simultaneous)
 
         async def request(value: float):

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -21,7 +21,7 @@ class TestThrottler:
         tuple(product((1, 3, 5), (0.5, 1.0, 1.5), (3, 5, 7))) +
         tuple(product((100, 1000), (0.5, 1.0, 1.5), (10, 1000)))
     )
-    def test_via_service(self, rate_limit: int, period: float, count: int):
+    def test_via_service(self, rate_limit: int, period: float, count: int, event_loop):
         s = Service(rate_limit, period)
 
         @throttle(rate_limit, period)

--- a/tests/test_throttler_simultaneous.py
+++ b/tests/test_throttler_simultaneous.py
@@ -10,7 +10,7 @@ class TestThrottlerSimultaneous:
     @pytest.mark.parametrize(
         ('max_simultaneous', 'count'), ((1, 10), (3, 10), (100, 500))
     )
-    def test_via_service_simultaneous(self, max_simultaneous: int, count: int):
+    def test_via_service_simultaneous(self, max_simultaneous: int, count: int, event_loop):
         s = ServiceSimultaneous(max_simultaneous)
 
         @throttle_simultaneous(max_simultaneous)


### PR DESCRIPTION
Use the `event_loop` fixture for tests that need one.

Without this, many tests fail in Python 3.14.0a2 because `asyncio.get_event_loop()` no longer automatically starts an event loop, instead raising a `RuntimeError` if there is no current event loop. See https://docs.python.org/dev/library/asyncio-eventloop.html#asyncio.get_event_loop, https://docs.python.org/dev/whatsnew/3.14.html#id3, and https://github.com/python/cpython/issues/126353.

For documentation on the fixture, see https://pytest-asyncio.readthedocs.io/en/latest/reference/fixtures/#event-loop.

Additionally, configure `asyncio_default_fixture_loop_scope` to `function`, which will be the default in a future release of `pytest-asyncio`. This isn’t specifically required for Python 3.14, but it fixes warnings like this:

```
PytestDeprecationWarning: The configuration option
"asyncio_default_fixture_loop_scope" is unset.  The event loop scope for
asynchronous fixtures will default to the fixture caching scope. Future
versions of pytest-asyncio will default the loop scope for asynchronous
fixtures to function scope. Set the default fixture loop scope
explicitly in order to avoid unexpected behavior in the future. Valid
fixture loop scopes are: "function", "class", "module", "package",
"session"
```